### PR TITLE
Speed and memory

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -783,7 +783,8 @@ rule giraffe_real_reads:
         fastq=fastq,
     output:
         # Giraffe can dump out pre-annotated reads at annotation range -1.
-        gam="{root}/aligned/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+        gam="{root}/annotated-1/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    log:"{root}/annotated-1/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     benchmark: "{root}/aligned/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.benchmark"
     wildcard_constraints:
         realness="real"
@@ -798,7 +799,7 @@ rule giraffe_real_reads:
         vg_binary = get_vg_version(wildcards.vgversion)
         flags=get_vg_flags(wildcards.vgflag)
 
-        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -f {input.fastq} " + flags + " >{output.gam}")
+        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -f {input.fastq} " + flags + " >{output.gam} 2>{log}")
 
 rule giraffe_sim_reads:
     input:
@@ -806,6 +807,7 @@ rule giraffe_sim_reads:
         gam=os.path.join(READS_DIR, "sim/{tech}/{sample}/{sample}-sim-{tech}-{subset}.gam"),
     output:
         gam="{root}/annotated-1/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    log:"{root}/annotated-1/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     wildcard_constraints:
         realness="sim"
     threads: auto_mapping_threads
@@ -817,7 +819,7 @@ rule giraffe_sim_reads:
         vg_binary = get_vg_version(wildcards.vgversion)
         flags=get_vg_flags(wildcards.vgflag)
 
-        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance --set-refpos -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam}")
+        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance --set-refpos -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam} 2>{log}")
 
 rule giraffe_sim_reads_with_correctness:
     input:
@@ -825,6 +827,7 @@ rule giraffe_sim_reads_with_correctness:
         gam=os.path.join(READS_DIR, "sim/{tech}/{sample}/{sample}-sim-{tech}-{subset}.gam"),
     output:
         gam="{root}/correctness/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    log:"{root}/correctness/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     wildcard_constraints:
         realness="sim"
     threads: auto_mapping_threads
@@ -836,7 +839,7 @@ rule giraffe_sim_reads_with_correctness:
         vg_binary = get_vg_version(wildcards.vgversion)
         flags=get_vg_flags(wildcards.vgflag)
 
-        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance --track-correctness --set-refpos -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam}")
+        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance --track-correctness --set-refpos -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam} 2>{log}")
 
 rule winnowmap_sim_reads:
     input:
@@ -847,6 +850,7 @@ rule winnowmap_sim_reads:
         mode=minimap_derivative_mode,
     output:
         sam="{root}/aligned-secsup/{reference}/winnowmap/{realness}/{tech}/{sample}{trimmedness}.{subset}.sam"
+    log:"{root}/aligned-secsup/{reference}/winnowmap/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     wildcard_constraints:
         realness="sim"
     wildcard_constraints:
@@ -859,7 +863,7 @@ rule winnowmap_sim_reads:
         runtime=600,
         slurm_partition=choose_partition(600)
     shell:
-        "winnowmap -t {threads} -W {input.repetitive_kmers} -ax {params.mode} {input.reference_fasta} {input.fastq} >{output.sam}"
+        "winnowmap -t {threads} -W {input.repetitive_kmers} -ax {params.mode} {input.reference_fasta} {input.fastq} >{output.sam} 2>{log}"
 
 rule winnowmap_real_reads:
     input:
@@ -870,6 +874,7 @@ rule winnowmap_real_reads:
         mode=minimap_derivative_mode,
     output:
         sam="{root}/aligned-secsup/{reference}/winnowmap/{realness}/{tech}/{sample}{trimmedness}.{subset}.sam"
+    log:"{root}/aligned-secsup/{reference}/winnowmap/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     benchmark: "{root}/aligned-secsup/{reference}/winnowmap/{realness}/{tech}/{sample}{trimmedness}.{subset}.benchmark"
     wildcard_constraints:
         realness="real"
@@ -885,7 +890,7 @@ rule winnowmap_real_reads:
         slurm_extra=auto_mapping_slurm_extra,
         full_cluster_nodes=auto_mapping_full_cluster_nodes
     shell:
-        "winnowmap -t {threads} -W {input.repetitive_kmers} -ax {params.mode} {input.reference_fasta} {input.fastq} >{output.sam}"
+        "winnowmap -t {threads} -W {input.repetitive_kmers} -ax {params.mode} {input.reference_fasta} {input.fastq} >{output.sam} 2>{log}"
 
 rule minimap2_index_reference:
     input:
@@ -1091,6 +1096,33 @@ rule wrong_from_comparison:
         slurm_partition=choose_partition(5)
     shell:
         "echo \"$(cat {input.compare} | grep -o '[0-9]* reads eligible' | cut -f1 -d' ') - $(cat {input.compare} | grep -o '[0-9]* reads correct' | cut -f1 -d' ')\" | bc -l >{output.tsv}"
+
+rule giraffe_speed_from_log:
+    input:
+        giraffe_log="{root}/annotated-1/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+    output:
+        tsv="{root}/stats/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_reads_per_second_per_thread.tsv"
+    threads: 1
+    resources:
+        mem_mb=200,
+        runtime=5,
+        slurm_partition=choose_partition(5)
+    shell:
+        "echo \"$(cat {input.giraffe_log} | grep \"reads per CPU-second\" | sed \'s/Achieved \([0-9]*\.[0-9]*\) reads per CPU-second.*/\\1/g\')\" >{output.tsv}"
+
+rule giraffe_memory_from_log:
+    input:
+        giraffe_log="{root}/annotated-1/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+    output:
+        tsv="{root}/stats/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_memory_GB.tsv"
+    threads: 1
+    resources:
+        mem_mb=200,
+        runtime=5,
+        slurm_partition=choose_partition(5)
+    shell:
+        "echo \"$(cat {input.giraffe_log} | grep \"Memory footprint\" | sed \'s/Memory footprint: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{output.tsv}"
+
 
 rule minimap2_speed_from_log:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -22,6 +22,9 @@ configfile: "lr-config.yaml"
 # hprc-v1.1-mc-chm13.d9.k31.w50.W.withzip.min
 # hprc-v1.1-mc-chm13.d9.k31.w50.W.zipcodes
 #
+# For old version of vg, use minimizers
+# hprc-v1.1-mc-chm13.d9.k31.w50.W.min
+#
 GRAPHS_DIR = config.get("graphs_dir", None) or "/private/groups/patenlab/anovak/projects/hprc/lr-giraffe/graphs"
 
 # Where are the reads to use?
@@ -322,10 +325,15 @@ def indexed_graph(wildcards):
     """
     base = graph_base(wildcards)
     indexes = dist_indexed_graph(wildcards)
-    new_indexes = {
-        "minfile": base + "." + wildcards["minparams"] + ".withzip.min",
-        "zipfile": base + "." + wildcards["minparams"] + ".zipcodes"
-    }
+    if wildcards["vgversion"] == "upstream":
+        new_indexes = {
+            "minfile": base + "." + wildcards["minparams"] + ".min",
+        }
+    else:
+        new_indexes = {
+            "minfile": base + "." + wildcards["minparams"] + ".withzip.min",
+            "zipfile": base + "." + wildcards["minparams"] + ".zipcodes"
+        }
     new_indexes.update(indexes)
     return new_indexes
 
@@ -819,7 +827,10 @@ rule giraffe_real_reads:
         vg_binary = get_vg_version(wildcards.vgversion)
         flags=get_vg_flags(wildcards.vgflag)
 
-        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -f {input.fastq} " + flags + " >{output.gam} 2>{log}")
+        if wildcards.vgversion == "upstream":
+            shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -f {input.fastq} " + flags + " >{output.gam} 2>{log}")
+        else:
+            shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -f {input.fastq} " + flags + " >{output.gam} 2>{log}")
 
 rule giraffe_sim_reads:
     input:
@@ -860,6 +871,31 @@ rule giraffe_sim_reads_with_correctness:
         flags=get_vg_flags(wildcards.vgflag)
 
         shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance --track-correctness --set-refpos -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam} 2>{log}")
+
+#Old version of vg without --set-refpos
+rule giraffe_sim_reads_upstream:
+    input:
+        unpack(indexed_graph),
+        gam=os.path.join(READS_DIR, "sim/{tech}/{sample}/{sample}-sim-{tech}-{subset}.gam"),
+    output:
+        gam="{root}/aligned/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    log:"{root}/aligned/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+    wildcard_constraints:
+        realness="sim"
+        vgversion="upstream"
+        preset="default|fast"
+    threads: auto_mapping_threads
+    resources:
+        mem_mb=auto_mapping_memory,
+        runtime=600,
+        slurm_partition=choose_partition(600)
+    run:
+        vg_binary = get_vg_version(wildcards.vgversion)
+        flags=get_vg_flags(wildcards.vgflag)
+
+        shell(vg_binary + " giraffe -t{threads} --parameter-preset {wildcards.preset} --progress --track-provenance -Z {input.gbz} -d {input.dist} -m {input.minfile} -z {input.zipfile} -G {input.gam} " + flags + " >{output.gam} 2>{log}")
+ruleorder: giraffe_sim_reads_upstream > giraffe_sim_reads
+ruleorder: giraffe_sim_reads_upstream > giraffe_sim_reads_with_correctness
 
 rule winnowmap_sim_reads:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -1531,6 +1531,7 @@ rule experiment_mapping_stats_tsv:
         slurm_partition=choose_partition(60)
     shell:
         "join -t '\t' {input.sim} {input.real} >> {output.tsv}"
+ruleorder: experiment_mapping_stats_tsv > experiment_stat_table
 
 rule stats_from_alignments:
     input:
@@ -1881,7 +1882,7 @@ rule softclips_by_name_giraffe:
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.softclips_by_name.tsv"
     wildcard_constraints:
-        mapper="giraffe.*"
+        mapper="(giraffe.*|graphaligner)"
     threads: 5
     resources:
         mem_mb=2000,

--- a/Snakefile
+++ b/Snakefile
@@ -1288,7 +1288,7 @@ rule memory_from_log_bam:
         condition_name=condition_name
     wildcard_constraints:
         realness="real",
-        mapper="(minimap2-.*|winnowmap)"
+        mapper="(minimap2-.*|winnowmap|bwa)"
     threads: 1
     resources:
         mem_mb=200,

--- a/Snakefile
+++ b/Snakefile
@@ -1034,6 +1034,22 @@ rule annotate_alignments:
         slurm_partition=choose_partition(600)
     shell:
         "vg annotate -t16 -a {input.gam} -x {input.gbz} -m --search-limit=-1 >{output.gam}"
+ruleorder: giraffe_sim_reads > annotate_alignments
+
+rule de_annotate_sim_alignments:
+    input:
+        gam="{root}/annotated-1/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    output:
+        gam="{root}/aligned/{reference}/{refgraph}/giraffe-{minparams}-{preset}-{vgversion}-{vgflag}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam"
+    wildcard_constraints:
+        realness="sim"
+    threads: 1
+    resources:
+        mem_mb=2000,
+        runtime=5,
+        slurm_partition=choose_partition(5)
+    shell:
+        "ln {input.gam} {output.gam}"
 
 rule correct_from_comparison:
     input:
@@ -1188,7 +1204,7 @@ rule experiment_pr_plot_from_compared:
 
 rule stats_from_alignments:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         stats="{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gamstats.txt"
     threads: 16
@@ -1349,7 +1365,7 @@ rule experiment_chain_coverage_plot:
 
 rule best_chain_coverage:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.best_chain_coverage.tsv"
     threads: 5
@@ -1362,7 +1378,7 @@ rule best_chain_coverage:
 
 rule chain_anchors_by_name_giraffe:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.best_chain_anchors_by_name.tsv"
     wildcard_constraints:
@@ -1422,7 +1438,7 @@ rule remove_names:
 
 rule time_used:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.time_used.tsv"
     threads: 5
@@ -1435,7 +1451,7 @@ rule time_used:
 
 rule stage_time:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.stage_{stage}_time.tsv"
     threads: 5
@@ -1448,7 +1464,7 @@ rule stage_time:
 
 rule aligner_part_stat:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.aligner_{aligner}_{part}_{stat}.tsv"
     wildcard_constraints:
@@ -1464,7 +1480,7 @@ rule aligner_part_stat:
 # We also want to get the fraction of the read processed by each aligner
 rule aligner_part_fraction:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.aligner_{aligner}_{part}_fraction.tsv"
     threads: 5
@@ -1478,7 +1494,7 @@ rule aligner_part_fraction:
 # And the speed in bases per second
 rule aligner_part_speed:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.aligner_{aligner}_{part}_speed.tsv"
     threads: 5
@@ -1492,7 +1508,7 @@ rule aligner_part_speed:
 # And the problem sizes
 rule aligner_part_probsize:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.aligner_{aligner}_{part}_probsize.tsv"
     threads: 5
@@ -1531,7 +1547,7 @@ rule length_by_correctness:
 
 rule softclips_by_name_giraffe:
     input:
-        gam="{root}/annotated-1/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
+        gam="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.gam",
     output:
         "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.softclips_by_name.tsv"
     wildcard_constraints:

--- a/Snakefile
+++ b/Snakefile
@@ -1096,7 +1096,7 @@ rule minimap2_speed_from_log:
     input:
         minimap2_log="{root}/aligned-secsup/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     output:
-        tsv="{root}/stats/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reads_per_second_per_thread.tsv"
+        tsv="{root}/stats/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_reads_per_second_per_thread.tsv"
     threads: 1
     resources:
         mem_mb=200,
@@ -1104,6 +1104,19 @@ rule minimap2_speed_from_log:
         slurm_partition=choose_partition(5)
     shell:
         "echo \"($(cat {input.minimap2_log} | grep \"mapped\" | awk \'{{sum+=$3}} END {{print sum}}\') / ($(cat {input.minimap2_log} | grep \"\\[M::main\\] Real time\" | sed \'s/.*Real time: \([0-9]*\.[0-9]*\) sec.*/\\1/g\') - $(cat {input.minimap2_log} | grep \"loaded/built the index\" | sed \'s/.M::main::\([0-9]*\.[0-9]*\).*/\\1 /g\'))) / $(cat {input.minimap2_log} | grep \"CMD:\" | sed \'s/.*-t\s\([0-9]*\)\s.*/\\1/g\')\" | bc -l >{output.tsv}"
+
+rule minimap2_memory_from_log:
+    input:
+        minimap2_log="{root}/aligned-secsup/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+    output:
+        tsv="{root}/stats/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_memory_GB.tsv"
+    threads: 1
+    resources:
+        mem_mb=200,
+        runtime=5,
+        slurm_partition=choose_partition(5)
+    shell:
+        "echo \"$(cat {input.minimap2_log} | grep \"Peak RSS\" | sed \'s/.*Peak RSS: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{output.tsv}"
 
 rule comparison_experiment_stat:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -1446,9 +1446,11 @@ rule experiment_memory_from_benchmark_plot:
 #Get the accuracy from simulated reads for one condition
 rule experiment_mapping_stats_sim_tsv_from_stats:
     input:
-        tsv="{root}/stats/{reference}/{refgraph}/{mapper}/sim/{tech}/{sample}{trimmedness}.{subset}.mapping_accuracy.tsv"
+        tsv="{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.mapping_accuracy.tsv"
     output:
-        tsv="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/sim/{tech}/{sample}{trimmedness}.{subset}.mapping_accuracy.tsv"
+        tsv="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.mapping_accuracy.tsv"
+    wildcard_constraints:
+        realness="sim"
     params:
         condition_name=condition_name
     threads: 1
@@ -1476,10 +1478,10 @@ rule experiment_mapping_stats_sim_tsv:
 #Get the speed, memory use, and softclips from real reads for each condition
 rule experiment_mapping_stats_real_tsv_from_stats:
     input:
-        speed_from_log="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.speed_from_log.tsv"
-        memory_from_log="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.memory_from_log.tsv"
-        runtime_from_benchmark="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.runtime_from_benchmark.tsv"
-        memory_from_benchmark="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.memory_from_benchmark.tsv"
+        speed_from_log="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.speed_from_log.tsv",
+        memory_from_log="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.memory_from_log.tsv",
+        runtime_from_benchmark="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.runtime_from_benchmark.tsv",
+        memory_from_benchmark="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.memory_from_benchmark.tsv",
         softclips="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.softclips.tsv"
     output:
         tsv="{root}/experiments/{expname}/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.mapping_stats_real.tsv"

--- a/Snakefile
+++ b/Snakefile
@@ -1948,7 +1948,7 @@ rule runtime_from_benchmark_bam:
         f = open(input.bench)
         assert(f.readline().split()[1] == "h:m:s")
         runtime_list = f.readline().split()[1].split(":")
-        runtime = (int(runtime_list[0]) * 60) + (int(runtime_list[1]) / 60)
+        runtime = (int(runtime_list[0]) * 60) + int(runtime_list[1]) + (int(runtime_list[2]) / 60)
         f.close()
 
         shell("echo \"{params.condition_name}\t{runtime}\" >{output.tsv}")
@@ -1972,7 +1972,7 @@ rule runtime_from_benchmark_gam:
         f = open(input.bench)
         assert(f.readline().split()[1] == "h:m:s")
         runtime_list = f.readline().split()[1].split(":")
-        runtime = (int(runtime_list[0]) * 60) + (int(runtime_list[1]) / 60)
+        runtime = (int(runtime_list[0]) * 60) + int(runtime_list[1]) + (int(runtime_list[2]) / 60)
         f.close()
 
         shell("echo \"{params.condition_name}\t{runtime}\" >{output.tsv}")

--- a/Snakefile
+++ b/Snakefile
@@ -1094,9 +1094,11 @@ rule wrong_from_comparison:
 
 rule minimap2_speed_from_log:
     input:
-        minimap2_log="{root}/aligned-secsup/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+        minimap2_log="{root}/aligned-secsup/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     output:
-        tsv="{root}/stats/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_reads_per_second_per_thread.tsv"
+        tsv="{root}/stats/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_reads_per_second_per_thread.tsv"
+    wildcard_constraints:
+        mapper="(minimap2-.*|winnowmap)"
     threads: 1
     resources:
         mem_mb=200,
@@ -1107,9 +1109,11 @@ rule minimap2_speed_from_log:
 
 rule minimap2_memory_from_log:
     input:
-        minimap2_log="{root}/aligned-secsup/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
+        minimap2_log="{root}/aligned-secsup/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     output:
-        tsv="{root}/stats/{reference}/minimap2-{minimapmode}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_memory_GB.tsv"
+        tsv="{root}/stats/{reference}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.reported_memory_GB.tsv"
+    wildcard_constraints:
+        mapper="(minimap2-.*|winnowmap)"
     threads: 1
     resources:
         mem_mb=200,

--- a/Snakefile
+++ b/Snakefile
@@ -2353,7 +2353,7 @@ rule plot_correct_speed_vs_parameter:
         header = infile.readline().split()
         parameter_col = str(header.index(wildcards.parameter)+1) 
         infile.close()
-        shell("cat <(cat {input.tsv} | grep -v '#' | awk '{{print $" + parameter_col + " \"\\t\" $4}}' | sed 's/^/RPS /g') <(cat {input.tsv} | grep -v '#' | awk '{{print $" + parameter_col + " \"\\t\" $1}}' | sed 's/^/Correct /g') | ./scatter.py --title 'Speed vs Correctness vs " + wildcards.parameter + "' --x_label " + wildcards.parameter + "  --y_per_category --categories 'RPS' 'Correct' --y_label 'Reads per Second' 'Reads Correct' --legend_overlay 'best' --save {output.plot} /dev/stdin")
+        shell("cat <(cat {input.tsv} | grep -v '#' | awk '{{print $" + parameter_col + " \"\\t\" $5}}' | sed 's/^/RPS /g') <(cat {input.tsv} | grep -v '#' | awk '{{print $" + parameter_col + " \"\\t\" $1}}' | sed 's/^/Correct /g') | ./scatter.py --title 'Speed vs Correctness vs " + wildcards.parameter + "' --x_label " + wildcards.parameter + "  --y_per_category --categories 'RPS' 'Correct' --y_label 'Reads per Second' 'Reads Correct' --legend_overlay 'best' --save {output.plot} /dev/stdin")
 
 rule parameter_search_stat:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -1144,7 +1144,7 @@ rule speed_from_log_giraffe:
         runtime=5,
         slurm_partition=choose_partition(5)
     shell:
-        "echo \"{{params.condition_name}}\t$(cat {{input.giraffe_log}} | grep \"reads per CPU-second\" | sed \'s/Achieved \([0-9]*\.[0-9]*\) reads per CPU-second.*/\\1/g\')\" >{{output.tsv}}"
+        "echo \"{params.condition_name}\t$(cat {input.giraffe_log} | grep \"reads per CPU-second\" | sed \'s/Achieved \([0-9]*\.[0-9]*\) reads per CPU-second.*/\\1/g\')\" >{output.tsv}"
 
 rule memory_from_log_giraffe:
     input:
@@ -1162,7 +1162,7 @@ rule memory_from_log_giraffe:
         runtime=5,
         slurm_partition=choose_partition(5)
     shell:
-        "echo \"{{params.condition_name}}\t$(cat {{input.giraffe_log}} | grep \"Memory footprint\" | sed \'s/Memory footprint: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{{output.tsv}}"
+        "echo \"{params.condition_name}\t$(cat {input.giraffe_log} | grep \"Memory footprint\" | sed \'s/Memory footprint: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{output.tsv}"
 
 
 rule speed_from_log_bam:
@@ -1205,7 +1205,7 @@ rule memory_from_log_bam:
         runtime=5,
         slurm_partition=choose_partition(5)
     shell:
-        "echo \"{{params.condition_name}}\t$(cat {{input.minimap2_log}} | grep \"Peak RSS\" | sed \'s/.*Peak RSS: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{output.tsv}"
+        "echo \"{params.condition_name}\t$(cat {input.minimap2_log} | grep \"Peak RSS\" | sed \'s/.*Peak RSS: \([0-9]*\.[0-9]*\) GB.*/\\1/g\')\" >{output.tsv}"
 
 
 rule comparison_experiment_stat:

--- a/Snakefile
+++ b/Snakefile
@@ -1172,8 +1172,6 @@ rule memory_from_log_giraffe_stat:
         giraffe_log="{root}/aligned/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     output:
         tsv="{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.memory_from_log.tsv"
-    params:
-        condition_name=condition_name
     wildcard_constraints:
         realness="real",
         mapper="giraffe.*"

--- a/Snakefile
+++ b/Snakefile
@@ -1250,7 +1250,7 @@ rule speed_from_log_bwa:
     shell:
         """
         mapped_count=$(cat {input.bwa_log} | grep "Processed" | awk '{{sum+=$3}} END {{print sum}}')
-        total_time=$(cat {input.bwa_log} | grep "Processed" | sed 's/.*\([0-9]*\.[0-9]*\) CPU sec.*/\\1/g' | awk '{{sum+=$1}} END {{print sum}}')
+        total_time=$(cat {input.bwa_log} | grep "Processed" | sed 's/.*in \([0-9]*\.[0-9]*\) CPU sec.*/\\1/g' | awk '{{sum+=$1}} END {{print sum}}')
         echo "{params.condition_name}\t$(echo "$mapped_count / $total_time" | bc -l)" >{output.tsv}
         """
 

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -75,6 +75,7 @@
 
 #graphs_dir: "/private/groups/patenlab/xhchang/graphs/lr_giraffe_graphs"
 real_slurm_extra: "--exclude=phoenix-[00-10,22-24]"
+exclusive_timing: false
 
 experiments:
   # This experiment tests all the mappers, realnesses, technologies, and


### PR DESCRIPTION
- Get stats for speed and memory from the benchmark and log files
- Make a table for mapping stats for experiments `{root}/experiments/{expname}/results/mapping_stats.tsv`
- Add memory and softclips to parameter search table