### PR TITLE
Paper figures and tables

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3498,6 +3498,7 @@ rule haplotype_sampling_time_empty:
         # Don't operate on sampled refgraphs.
         # Say we need a refgraph that's a bit not followed by a sampling indicator, followed by a dash and something. Or "primary".
         refgraph="((?!model)(?!legacy)(?!olddv)(?!newdv)[^/_]+(?!-sampled[0-9]+d?o?)-[^-]+|primary)",
+        mapper="!(giraffe.*)"
     threads: 1
     resources:
         mem_mb=200,
@@ -3538,6 +3539,8 @@ rule haplotype_sampling_time_giraffe:
             runtime += 24 * 60 * days
             f.close()
         shell("echo \"{params.condition_name}\t{runtime}\" >{output.tsv}")
+
+ruleorder: haplotype_sampling_time_giraffe > haplotype_sampling_time_empty
 
 #output tsv of:
 #condition name, index load time plus haplotype sampling time in minutes

--- a/Snakefile
+++ b/Snakefile
@@ -4241,7 +4241,7 @@ rule experiment_mapping_stats_real_tsv:
         slurm_partition=choose_partition(60)
     shell:
         """
-        printf "condition\truntime(min)\tstartup_time(min)\tsampling_time(min)\tmemory(GB)\tsoftclipped(bp)\thardclipped(bp)\tunmapped(bp)\ttotal(bp)\n\ttotal_read_bases(bp)" >> {output.tsv} 
+        printf "condition\truntime(min)\tstartup_time(min)\tsampling_time(min)\tmemory(GB)\tsoftclipped(bp)\thardclipped(bp)\tunmapped(bp)\ttotal(bp)\ttotal_read_bases(bp)\n" >> {output.tsv} 
         cat {input} /dev/null >>{output.tsv}
         """
 ruleorder: experiment_mapping_stats_real_tsv > experiment_stat_table
@@ -6012,7 +6012,6 @@ ruleorder: sv_summary_table > experiment_stat_table
 rule all_paper_figures:
     input:
         mapping_stats_real=expand(ALL_OUT_DIR + "/experiments/{expname}/results/mapping_stats_real.tsv", expname=config["real_exps"]),
-        mapping_stats_real_latex=expand(ALL_OUT_DIR + "/experiments/{expname}/results/mapping_stats_real.latex.tsv", expname=config["real_exps"]),
         mapping_stats_sim=expand(ALL_OUT_DIR + "/experiments/{expname}/results/mapping_stats_sim.tsv", expname=config["sim_exps"]),
         compared_sim=expand(ALL_OUT_DIR + "/experiments/{expname}/results/compared.tsv", expname=config["sim_exps"]),
         dv_indel=expand(ALL_OUT_DIR + "/experiments/{expname}/results/dv_indel_summary.tsv", expname=config["dv_exps"]),

--- a/Snakefile
+++ b/Snakefile
@@ -324,7 +324,7 @@ def auto_mapping_memory(wildcards):
 
     base_mb = 60000
 
-    if wildcards["tech"] == "illumina":
+    if wildcards["tech"] == "illumina" or wildcards["tech"] == "element":
         scale_mb = 200000
     elif wildcards["tech"] == "hifi":
         scale_mb = 240000
@@ -459,6 +459,7 @@ def minimap_derivative_mode(wildcards):
         "r10": "map-ont",
         "r10y2025": "map-ont",
         "hifi": "map-pb",
+        "element": "sr",
         "illumina": "sr" # Only Minimap2 has this one, Winnowmap doesn't.
     }
 
@@ -2217,7 +2218,7 @@ rule winnowmap_sim_reads:
     wildcard_constraints:
         # Winnowmap doesn't have a short read preset, so we can't do Illumina reads.
         # So match any string but that. See https://stackoverflow.com/a/14683066
-        tech="(?!illumina).+"
+        tech="(?!(illumina|element)).+"
     threads: auto_mapping_threads
     resources:
         mem_mb=300000,
@@ -2242,7 +2243,7 @@ rule winnowmap_real_reads:
     wildcard_constraints:
         # Winnowmap doesn't have a short read preset, so we can't do Illumina reads.
         # So match any string but that. See https://stackoverflow.com/a/14683066
-        tech="(?!illumina).+"
+        tech="(?!(illumina|element)).+"
     threads: auto_mapping_threads
     params:
         exclusive_timing=exclusive_timing
@@ -2379,7 +2380,7 @@ rule bwa_sim_reads:
     log:"{root}/aligned-secsup/{reference}/bwa{pairing}/{realness}/{tech}/{sample}{trimmedness}.{subset}.log"
     wildcard_constraints:
         realness="sim",
-        tech="illumina",
+        tech="(illumina|element)",
         pairing="(-pe|)"
     params:
         pairing_flag=lambda w: "-p" if w["pairing"] == "-pe" else ""
@@ -4867,7 +4868,7 @@ rule softclips_by_name_gam:
         mapper="(minigraph|graphaligner-.*|giraffe.*)",
         # This is too slow to do for Illumina; we're supposed to use _empty
         # rules later to fill in 0s for Illumina conditions.
-        tech="(?!illumina)[a-zA-Z0-9]+"
+        tech="(?!(illumina|element))[a-zA-Z0-9]+"
     threads: 5
     resources:
         mem_mb=2000,
@@ -4893,7 +4894,7 @@ rule softclips_by_name_other:
         mapper="(?!(minigraph|graphaligner-.*|giraffe.*)).+",
         # This is too slow to do for Illumina; we're supposed to use _empty
         # rules later to fill in 0s for Illumina conditions.
-        tech="(?!illumina)[a-zA-Z0-9]+"
+        tech="(?!(illumina|element))[a-zA-Z0-9]+"
     threads: 9
     resources:
         mem_mb=2000,
@@ -4946,7 +4947,7 @@ rule hardclips_by_name_gam:
         mapper="(minigraph|graphaligner-.*|giraffe.*)",
         # This is too slow to do for Illumina; we're supposed to use _empty
         # rules later to fill in 0s for Illumina conditions.
-        tech="(?!illumina)[a-zA-Z0-9]+"
+        tech="(?!(illumina|element))[a-zA-Z0-9]+"
     threads: 2
     resources:
         mem_mb=28000,
@@ -4975,7 +4976,7 @@ rule hardclips_by_name_other:
         mapper="(?!(minigraph|graphaligner-.*|giraffe.*)).+",
         # This is too slow to do for Illumina; we're supposed to use _empty
         # rules later to fill in 0s for Illumina conditions.
-        tech="(?!illumina)[a-zA-Z0-9]+"
+        tech="(?!(illumina|element))[a-zA-Z0-9]+"
     threads: 7
     resources:
         mem_mb=2000,
@@ -5039,7 +5040,7 @@ rule clipped_empty:
     output:
          "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.clipped.tsv"
     wildcard_constraints:
-        tech="illumina"
+        tech="(illumina|element)"
     threads: 1
     resources:
         mem_mb=400,
@@ -5078,7 +5079,7 @@ rule clipped_or_unmapped_empty:
     output:
          "{root}/stats/{reference}/{refgraph}/{mapper}/{realness}/{tech}/{sample}{trimmedness}.{subset}.clipped_or_unmapped.tsv"
     wildcard_constraints:
-        tech="illumina"
+        tech="(illumina|element)"
     threads: 1
     resources:
         mem_mb=400,

--- a/barchart.py
+++ b/barchart.py
@@ -261,7 +261,7 @@ def main(args):
     pyplot.xlabel(options.x_label)
     
     # Label the columns with the appropriate text. Account for 1-based ticks.
-    pyplot.xticks([x for x in range(len(categories.keys()))],
+    pyplot.xticks([x for x in range(len(category_order))],
         category_labels, rotation=90 if options.x_sideways else 0)
     
     pyplot.ylabel(options.y_label)

--- a/format_tsv.sh
+++ b/format_tsv.sh
@@ -1,0 +1,19 @@
+cat $1 | \
+awk -v OFS='\t' '{split($1, a, ","); print a[2],a[1],$0}' | cut -f 1,2,4- | \
+sed 's/hprc-v1.1-mc-sampled32d/HPRC-v1-Sampled32d/g' | \
+sed 's/hprc-v2.0-mc-eval-d46/HPRC-d46/g' | \
+sed 's/hprc-v2.0-mc-eval.ec1M-sampled16o/HPRC-sampled16/g' | \
+sed 's/hprc-v2.0-minigraph-eval/HPRC-minigraph/g' | \
+sed 's/primary/CHM13/g' | \
+sed 's/giraffe/Giraffe/g' | \
+sed 's/bwa/BWA-MEM/g' | \
+sed 's/mini/Mini/g' | \
+sed 's/graphaligner/GraphAligner/g' | \
+sed 's/pbmm2/PBMM2/g' | \
+sed 's/winnowmap/Winnowmap/g' | \
+sed 's/HPRC-d46\tBWA-MEM/CHM13\tBWA-MEM/g' | \
+sed 's/HPRC-d46\tMinimap2/CHM13\tMinimap2/g' | \
+sed 's/HPRC-d46\tWinnowmap/CHM13\tWinnowmap/g' | \
+sed 's/HPRC-d46\tPBMM2/CHM13\tPBMM2/g' | \
+sed 's/\t/\t\& /g'  | sed 's/$/ \\\\/g' | \
+sort

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -89,10 +89,10 @@ min_exclusive_reads: 1000000
 
 real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full", "element_real_full"]
 sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m"]
-headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline", "illumina_sim_1m", "element_sim_1m"]
-headline_real_exps: ["hifi_real_full_headline", "r10y2025_real_full_headline"]
-dv_exps: ["dv_calling"]
-sv_exps: ["sv_calling"]
+dv_exps: []
+#"dv_calling"]
+sv_exps: []
+#"sv_calling"]
 
 non_zipcode_giraffe_versions: ["230872", "v1.62.0"]
 
@@ -182,53 +182,6 @@ experiments:
           mapper: ["giraffe-k29.w11-default-99930d-noflags"]
         - refgraph: "primary"
           mapper: ["giraffe-k29.w11-default-99930d-noflags"]
-
-
-  r10y2025_real_full_headline:
-    control:
-      subset: full
-      reference: chm13
-      tech: r10y2025
-      sample: HG002
-      realness: real
-    vary:
-      mapper: ["minimap2-map-ont", "minimap2-lr:hqae", "winnowmap", "graphaligner-default", "graphaligner-fast", "minigraph", "giraffe-k31.w50.W-r10-99930d-noflags"]
-      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v2.0-minigraph-eval", "primary"]
-    constrain:
-        - refgraph: "hprc-v2.0-mc-eval-d46"
-          # graphaligner-default timed out after 7 days in Slurm job 9705975
-          mapper: ["minimap2-lr:hqae", "winnowmap", "graphaligner-fast", "giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o"]
-          mapper: ["giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: "primary"
-          mapper: ["giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: "hprc-v2.0-minigraph-eval"
-          mapper: ["minigraph", "graphaligner-default"]
-
-  #This is used to test different mappers on hifi reads
-  #Add vg versions with `-commit` instead of `-default`, and make sure the binary
-  # is called `vg_commit`
-  hifi_real_full_headline:
-    control:
-      subset: full
-      tech: hifi
-      reference: chm13
-      sample: HG002
-      realness: real
-    vary:
-      mapper: ["minimap2-map-pb", "minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "winnowmap", "graphaligner-default", "graphaligner-fast", "minigraph", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v2.0-minigraph-eval", "primary"]
-    constrain:
-        - refgraph: "hprc-v2.0-mc-eval-d46"
-          # graphaligner-default timed out after 7 days in Slurm job 9705958
-          mapper: ["minimap2-map-hifi", "pbmm2", "winnowmap", "graphaligner-fast", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o"]
-          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: "primary"
-          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: "hprc-v2.0-minigraph-eval"
-          # graphaligner-default timed out after 7 days in Slurm job 9705974
-          mapper: ["minigraph"]
 
   r10_sim_1m:
     control:
@@ -381,47 +334,6 @@ experiments:
           mapper: ["minimap2-sr", "bwa", "giraffe-k29.w11-default-v1.64.1-noflags"]
         - refgraph: "primary"
           mapper: ["giraffe-k29.w11-default-v1.64.1-noflags"]
-
-  r10y2025_sim_1m_headline:
-    control:
-      subset: 1m
-      reference: chm13
-      tech: r10y2025
-      sample: HG002
-      realness: sim
-    vary:
-      mapper: ["minimap2-map-ont", "minimap2-lr:hqae", "winnowmap", "graphaligner-default", "graphaligner-fast", "minigraph", "giraffe-k31.w50.W-r10-99930d-noflags"]
-      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v2.0-minigraph-eval", "primary"]
-    constrain:
-        - refgraph: "hprc-v2.0-mc-eval-d46"
-          mapper: ["minimap2-lr:hqae", "winnowmap", "graphaligner-default", "giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o"]
-          mapper: ["giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: "primary"
-          mapper: ["giraffe-k31.w50.W-r10-99930d-noflags"]
-        - refgraph: "hprc-v2.0-minigraph-eval"
-          mapper: ["minigraph", "graphaligner-default"]
-  hifi_sim_1m_headline:
-    control:
-      subset: 1m
-      tech: hifi
-      reference: chm13
-      sample: HG002
-      realness: sim
-    vary:
-      mapper: ["minimap2-map-pb", "minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "winnowmap", "graphaligner-default", "graphaligner-fast", "minigraph", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v2.0-minigraph-eval", "primary"]
-    constrain:
-        - refgraph: "hprc-v2.0-mc-eval-d46"
-          mapper: ["minimap2-map-hifi", "pbmm2", "winnowmap", "graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o"]
-          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: "primary"
-          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100"]
-        - refgraph: "hprc-v2.0-minigraph-eval"
-          mapper: ["minigraph", "graphaligner-default"]
-
-
 
   #For variant calling
   dv_calling:

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -440,7 +440,7 @@ experiments:
       truthref: ["chm13", "grch38"]
       caller: ["vgcall", "sniffles"]
       tech: ["hifi", "r10y2025"]
-      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-default"]
       refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o"]
     constrain:
       - 
@@ -463,16 +463,23 @@ experiments:
         - caller: ["vgcall"]
           mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
         - caller: ["sniffles"]
-          mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae"]
+          mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
       - 
         # Use the same mapping and calling reference for minimap, but vary the calling reference for graphs
-        - caller: ["sniffles"]
+        - mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae"]
+          caller: ["sniffles"]
           truthref: ["chm13"]
           reference: ["chm13"]
-        - caller: ["sniffles"]
+        - mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae"]
+          caller: ["sniffles"]
           truthref: ["grch38"]
           reference: ["grch38"]
-        - caller: ["vgcall"]
+        - mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+          caller: ["sniffles"]
+          truthref: ["chm13"]
+          reference: ["chm13"]
+        - mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+          caller: ["vgcall"]
           truthref: ["chm13", "grch38"]
           reference: ["chm13"]
 

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -88,8 +88,9 @@ min_exclusive_reads: 1000000
 # Note that reserving a full node is the only way we have to ensure a job is not split across NUMA nodes
 
 real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full"]
-sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m", "illumina_sim_1m"]
-headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline"]
+sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m"]
+headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline", "illumina_sim_1m"]
+#, "element_sim_1m"]
 headline_real_exps: ["hifi_real_full_headline", "r10y2025_real_full_headline"]
 dv_exps: ["dv_calling"]
 sv_exps: ["sv_calling"]
@@ -292,12 +293,30 @@ experiments:
     vary:
       mapper: ["pbmm2", "winnowmap", "giraffe-k31.w50.W-hifi-99930d-noflags", "giraffe-k31.w50.W-hifi-99930d-mmcs80", "giraffe-k31.w50.W-hifi-99930d-mmcs90", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-hifi-99930d-mmcs120", "giraffe-k31.w50.W-hifi-99930d-mmcs140", "giraffe-k31.w50.W-hifi-99930d-mmcs160", "giraffe-k31.w50.W-hifi-99930d-mmcs180", "giraffe-k31.w50.W-hifi-99930d-mmcs200"]
       refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o"]
-   
+    
   illumina_sim_1m:
     control:
       subset: 1m
       reference: chm13
       tech: illumina
+      sample: HG002
+      realness: sim
+    vary:
+      mapper: ["minimap2-sr", "bwa", "giraffe-k29.w11-default-99930d-noflags"]
+      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v1.1-mc-sampled32d", "primary"]
+    constrain:
+        - refgraph: "hprc-v2.0-mc-eval-d46"
+          mapper: ["minimap2-sr", "bwa", "giraffe-k29.w11-default-99930d-noflags"]
+        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v1.1-mc-sampled32d"]
+          mapper: ["giraffe-k29.w11-default-99930d-noflags"]
+        - refgraph: "primary"
+          mapper: ["giraffe-k29.w11-default-99930d-noflags"]
+
+  element_sim_1m:
+    control:
+      subset: 1m
+      reference: chm13
+      tech: element
       sample: HG002
       realness: sim
     vary:

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -89,10 +89,8 @@ min_exclusive_reads: 1000000
 
 real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full", "element_real_full"]
 sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m"]
-dv_exps: []
-#"dv_calling"]
-sv_exps: []
-#"sv_calling"]
+dv_exps: ["dv_calling"]
+sv_exps: ["sv_calling"]
 
 non_zipcode_giraffe_versions: ["230872", "v1.62.0"]
 
@@ -345,20 +343,20 @@ experiments:
       trimmedness: ""
     vary:
       tech: ["hifi", "r10y2025"]
-      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-default"]
+      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-fast"]
       refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o"]
       callparams: [".nomodel", ".model2025-03-26noinfo"]
     constrain:
       - 
         # Use the right mapping preset for each tech
         - tech: "hifi"
-          mapper: ["minimap2-map-hifi", "pbmm2", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "graphaligner-default"]
+          mapper: ["minimap2-map-hifi", "pbmm2", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "graphaligner-fast"]
         - tech: "r10y2025"
-          mapper: ["minimap2-lr:hqae", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-default"]
+          mapper: ["minimap2-lr:hqae", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-fast"]
       -
         # Use the right calling model for each tech and mapper
         - tech: "hifi"
-          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100", "graphaligner-default"]
+          mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100", "graphaligner-fast"]
           callparams: ".model2025-03-26noinfo"
         - tech: "hifi"
           mapper: ["minimap2-map-hifi", "pbmm2"]
@@ -367,7 +365,7 @@ experiments:
           callparams: ".nomodel"
       - 
         # Don't use the linear mappers on all the graphs
-        - mapper: ["graphaligner-default"]
+        - mapper: ["graphaligner-fast"]
           refgraph: ["hprc-v2.0-mc-eval-d46"]
         - mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
           refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o"]
@@ -389,20 +387,20 @@ experiments:
       truthref: ["chm13", "grch38"]
       caller: ["vgcall", "sniffles"]
       tech: ["hifi", "r10y2025"]
-      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-default"]
+      mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags", "graphaligner-fast"]
       refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o"]
     constrain:
       - 
         # Use the right mapping preset for each tech
         - tech: "hifi"
-          mapper: ["minimap2-map-hifi", "pbmm2", "graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
+          mapper: ["minimap2-map-hifi", "pbmm2", "graphaligner-fast", "giraffe-k31.w50.W-hifi-99930d-mmcs100"]
         - tech: "r10y2025"
-          mapper: ["minimap2-lr:hqae", "graphaligner-default", "giraffe-k31.w50.W-r10-99930d-noflags"]
+          mapper: ["minimap2-lr:hqae", "graphaligner-fast", "giraffe-k31.w50.W-r10-99930d-noflags"]
       - 
         # Don't use the linear mappers on all the graphs
         - mapper: ["giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
           refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o"]
-        - mapper: ["graphaligner-default"]
+        - mapper: ["graphaligner-fast"]
           # GraphAligner timed out on both techs after 7 days, on hprc-v2.0-mc-eval-d46.
           refgraph: ["hprc-v2.0-mc-eval-d46"]
         - mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae"]
@@ -410,7 +408,7 @@ experiments:
       - 
         #Use linear mappers with sniffles and graph mappers with vgcall
         - caller: ["vgcall"]
-          mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+          mapper: ["graphaligner-fast", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
         - caller: ["sniffles"]
           mapper: ["minimap2-map-hifi", "pbmm2", "minimap2-lr:hqae", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
       - 
@@ -423,11 +421,11 @@ experiments:
           caller: ["sniffles"]
           truthref: ["grch38"]
           reference: ["grch38"]
-        - mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+        - mapper: ["graphaligner-fast", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
           caller: ["sniffles"]
           truthref: ["chm13"]
           reference: ["chm13"]
-        - mapper: ["graphaligner-default", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
+        - mapper: ["graphaligner-fast", "giraffe-k31.w50.W-hifi-99930d-mmcs100", "giraffe-k31.w50.W-r10-99930d-noflags"]
           caller: ["vgcall"]
           truthref: ["chm13", "grch38"]
           reference: ["chm13"]

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -89,8 +89,7 @@ min_exclusive_reads: 1000000
 
 real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full"]
 sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m"]
-headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline", "illumina_sim_1m"]
-#, "element_sim_1m"]
+headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline", "illumina_sim_1m", "element_sim_1m"]
 headline_real_exps: ["hifi_real_full_headline", "r10y2025_real_full_headline"]
 dv_exps: ["dv_calling"]
 sv_exps: ["sv_calling"]

--- a/lr-config.yaml
+++ b/lr-config.yaml
@@ -87,7 +87,7 @@ exclusive_timing: true
 min_exclusive_reads: 1000000
 # Note that reserving a full node is the only way we have to ensure a job is not split across NUMA nodes
 
-real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full"]
+real_exps: ["hifi_real_full", "r10y2025_real_full", "illumina_real_full", "element_real_full"]
 sim_exps: ["hifi_sim_1m", "r10y2025_sim_1m"]
 headline_sim_exps: ["r10y2025_sim_1m_headline", "hifi_sim_1m_headline", "illumina_sim_1m", "element_sim_1m"]
 headline_real_exps: ["hifi_real_full_headline", "r10y2025_real_full_headline"]
@@ -164,6 +164,25 @@ experiments:
           mapper: ["giraffe-k29.w11-default-99930d-noflags"]
         - refgraph: "primary"
           mapper: ["giraffe-k29.w11-default-99930d-noflags"]
+
+  element_real_full:
+    control:
+      subset: full
+      reference: chm13
+      tech: element
+      sample: HG002
+      realness: real
+    vary:
+      mapper: ["minimap2-sr", "bwa", "giraffe-k29.w11-default-99930d-noflags"]
+      refgraph: ["hprc-v2.0-mc-eval-d46", "hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v1.1-mc-sampled32d", "primary"]
+    constrain:
+        - refgraph: "hprc-v2.0-mc-eval-d46"
+          mapper: ["minimap2-sr", "bwa", "giraffe-k29.w11-default-99930d-noflags"]
+        - refgraph: ["hprc-v2.0-mc-eval.ec1M-sampled16o", "hprc-v1.1-mc-sampled32d"]
+          mapper: ["giraffe-k29.w11-default-99930d-noflags"]
+        - refgraph: "primary"
+          mapper: ["giraffe-k29.w11-default-99930d-noflags"]
+
 
   r10y2025_real_full_headline:
     control:

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -117,23 +117,27 @@ INDEL_SUMMARY=${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv
 
 # Zoomed in headline roc plots
 
-Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.9545,0.995'
-
-Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline_zoomed.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.030,0.965,0.994'
-
-# Zoomed out headline roc plots
-Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
-
-Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
-
-Rscript plot-roc.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/roc_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.918,0.985'
-
-Rscript plot-roc.R ${ELEMENT_ACCURACY} ${OUT_DIR}/roc_element_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Element ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
-
-# headline qq plots
+##Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.9545,0.995'
+##
+##Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline_zoomed.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.030,0.965,0.994'
+##
+### Zoomed out headline roc plots
+##Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
+##
+##Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
+##
+##Rscript plot-roc.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/roc_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.918,0.985'
+##
+##Rscript plot-roc.R ${ELEMENT_ACCURACY} ${OUT_DIR}/roc_element_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Element ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
+##
+### headline qq plots
 Rscript plot-qq.R ${HIFI_ACCURACY} ${OUT_DIR}/qq_hifi_headline.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI QQ" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
 
 Rscript plot-qq.R ${R10_ACCURACY} ${OUT_DIR}/qq_r10_headline.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 QQ" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
+
+Rscript plot-qq.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/qq_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina QQ" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
+
+Rscript plot-qq.R ${ELEMENT_ACCURACY} ${OUT_DIR}/qq_element_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Element QQ" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
 
 ########################################## Incorrect counts
 

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -100,7 +100,7 @@ R10_ACCURACY=${ROOT_DIR}/experiments/r10y2025_sim_1m_headline/results/compared.t
 ILLUMINA_ACCURACY=${ROOT_DIR}/experiments/illumina_sim_1m/results/compared.tsv
 ELEMENT_ACCURACY=${ROOT_DIR}/experiments/element_sim_1m/results/compared.tsv
 
-Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.03,0.9775,0.995'
+Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.9545,0.995'
 
 Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline_zoomed.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.030,0.965,0.994'
 
@@ -224,4 +224,4 @@ Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp
 Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
 
 Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv ${OUT_DIR}/dv_snp_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
+#Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -2,7 +2,6 @@ set -ex
 
 ROOT_DIR=/private/groups/patenlab/project-lrg
 OUT_DIR=./plots
-
 mkdir -p "${OUT_DIR}"
 
 
@@ -110,7 +109,7 @@ Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline.pdf $(echo $HIF
 
 Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
 
-Rscript plot-roc.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/roc_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
+Rscript plot-roc.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/roc_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.918,0.985'
 
 Rscript plot-roc.R ${ELEMENT_ACCURACY} ${OUT_DIR}/roc_element_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Element ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
 
@@ -150,22 +149,36 @@ python3 barchart.py ${R10_CLIPS} --divisions ${R10_UNMAPPED} --title 'R10 Clippe
 
 ############################################ Runtime
 
-HIFI_RUNTIME=${ROOT_DIR}/experiments/hifi_real_full_headline/results/run_and_sampling_time_from_benchmark.tsv
-R10_RUNTIME=${ROOT_DIR}/experiments/r10y2025_real_full_headline/results/run_and_sampling_time_from_benchmark.tsv
-HIFI_INDEX_TIME=${ROOT_DIR}/experiments/hifi_real_full_headline/results/index_load_time.tsv
-R10_INDEX_TIME=${ROOT_DIR}/experiments/r10y2025_real_full_headline/results/index_load_time.tsv
+HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
+R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
+HIFI_RUNTIME=${OUT_DIR}/hifi_runtimes.tsv
+R10_RUNTIME=${OUT_DIR}/r10_runtimes.tsv
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} > ${HIFI_RUNTIME}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} > ${R10_RUNTIME}
+
+
 
 # Higher hifi runtimes
 LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) big)
-python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_INDEX_TIME}) --min ${LIMIT}  --title 'HiFi Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_hifi_headline_slow.pdf
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${HIFI_RUNTIME}) --min ${LIMIT}  --title 'HiFi Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_hifi_headline_slow.pdf
 
 # Lower hifi runtimes
 LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) small)
-python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_INDEX_TIME}) --max ${LIMIT}  --title 'HiFi Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_hifi_headline_fast.pdf
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${HIFI_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${HIFI_RUNTIME}) --max ${LIMIT}  --title 'HiFi Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_hifi_headline_fast.pdf
 
 # R10 runtimes as one plot
-python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_INDEX_TIME}) --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline.pdf
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${R10_RUNTIME}) --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline.pdf
 
+# Higher r10 runtimes
+LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) big)
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${R10_RUNTIME}) --min ${LIMIT}  --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline_slow.pdf
+
+# Lower R10 runtimes
+LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) small)
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${R10_RUNTIME}) --max ${LIMIT}  --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline_fast.pdf
+
+rm ${HIFI_RUNTIME}
+rm ${R10_RUNTIME}
 ###################################### Memory
 
 HIFI_MEMORY=${ROOT_DIR}/experiments/hifi_real_full_headline/results/memory_from_benchmark.tsv
@@ -175,3 +188,40 @@ python3 barchart.py ${HIFI_MEMORY} --title 'HiFi Memory From Benchmark' --y_labe
 
 python3 barchart.py ${R10_MEMORY} --title 'R10 Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_r10.pdf
 
+
+####################################### SV Calling
+
+GIRAFFE_VGCALL_HIFI=chm13,chm13,vgcall,hifi,giraffe-hifi-mmcs100,eval-d46
+GIRAFFE_SAMPLED_VGCALL_HIFI=chm13,chm13,vgcall,hifi,giraffe-hifi-mmcs100,eval.ec1M-sampled16o
+MINIMAP_SNIFFLES_HIFI=chm13,chm13,sniffles,hifi,minimap2-map-hifi,eval-d46
+
+GIRAFFE_VGCALL_R10=chm13,chm13,vgcall,r10y2025,giraffe-r10-noflags,eval-d46
+GIRAFFE_SAMPLED_VGCALL_R10=chm13,chm13,vgcall,r10y2025,giraffe-r10-noflags,eval.ec1M-sampled16o
+MINIMAP_SNIFFLES_R10=chm13,chm13,sniffles,r10y2025,minimap2-lr:hqae,eval-d46
+
+SV_CALLING_CONDITIONS_HIFI="${GIRAFFE_VGCALL_HIFI};${GIRAFFE_SAMPLED_VGCALL_HIFI};${MINIMAP_SNIFFLES_HIFI}"
+SV_CALLING_CONDITIONS_R10="${GIRAFFE_VGCALL_R10};${GIRAFFE_SAMPLED_VGCALL_R10};${MINIMAP_SNIFFLES_R10}"
+
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv ${OUT_DIR}/sv_summary_hifi.pdf ${SV_CALLING_CONDITIONS_HIFI}
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv ${OUT_DIR}/sv_summary_r10.pdf ${SV_CALLING_CONDITIONS_R10}
+
+############################################# DV Calling
+
+GIRAFFE_DV_HIFI=hifi,giraffe-hifi-mmcs100,eval-d46,.model2025-03-26noinfo
+GIRAFFE_SAMPLED_DV_HIFI=hifi,giraffe-hifi-mmcs100,eval.ec1M-sampled16o,.model2025-03-26noinfo
+MINIMAP_DV_HIFI=hifi,minimap2-map-hifi,eval-d46,.nomodel
+
+DV_CALLING_CONDITIONS_HIFI="${GIRAFFE_DV_HIFI};${GIRAFFE_SAMPLED_DV_HIFI};${MINIMAP_DV_HIFI}"
+
+GIRAFFE_DV_R10=r10y2025,giraffe-r10-noflags,eval-d46,.nomodel
+GIRAFFE_SAMPLED_DV_R10=r10y2025,giraffe-r10-noflags,eval.ec1M-sampled16o,.nomodel
+MINIMAP_DV_R10=r10y2025,minimap2-lr:hqae,eval-d46,.nomodel
+
+DV_CALLING_CONDITIONS_R10="${GIRAFFE_DV_R10};${GIRAFFE_SAMPLED_DV_R10};${MINIMAP_DV_R10}"
+
+
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv ${OUT_DIR}/dv_snp_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
+
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv ${OUT_DIR}/dv_snp_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
+Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -91,12 +91,14 @@ HIFI_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${PBMM_COLOR
 R10_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_R10} ${WINNOWMAP} ${GIRAFFE_PRIMARY_R10} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_MINIGRAPH} ${GRAPHALIGNER_FAST} ${GIRAFFE_R10} ${GIRAFFE_SAMPLED_R10}"
 R10_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${MINIGRAPH_MINIGRAPH_COLOR} ${GRAPHALIGNER_MINIGRAPH_COLOR} ${GRAPHALIGNER_FAST_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
+SR_REAL_FULL_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR} ${GIRAFFE_PRIMARY_SR}"
+SR_REAL_FULL_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR} ${GIRAFFE_PRIMARY_COLOR}"
 
-########################################## ROCs and QQs
+########################################### ROCs and QQs
 
 # Zoomed in headline roc plots
-HIFI_ACCURACY=${ROOT_DIR}/experiments/hifi_sim_1m_headline/results/compared.tsv
-R10_ACCURACY=${ROOT_DIR}/experiments/r10y2025_sim_1m_headline/results/compared.tsv
+HIFI_ACCURACY=${ROOT_DIR}/experiments/hifi_sim_1m/results/compared.tsv
+R10_ACCURACY=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/compared.tsv
 ILLUMINA_ACCURACY=${ROOT_DIR}/experiments/illumina_sim_1m/results/compared.tsv
 ELEMENT_ACCURACY=${ROOT_DIR}/experiments/element_sim_1m/results/compared.tsv
 
@@ -120,8 +122,8 @@ Rscript plot-qq.R ${R10_ACCURACY} ${OUT_DIR}/qq_r10_headline.pdf $(echo $R10_SIM
 
 ########################################## Incorrect counts
 
-HIFI_INCORRECT=${ROOT_DIR}/experiments/hifi_sim_1m_headline/results/mapping_stats_sim.tsv
-R10_INCORRECT=${ROOT_DIR}/experiments/r10y2025_sim_1m_headline/results/mapping_stats_sim.tsv
+HIFI_INCORRECT=${ROOT_DIR}/experiments/hifi_sim_1m/results/mapping_stats_sim.tsv
+R10_INCORRECT=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/mapping_stats_sim.tsv
 
 python3 barchart.py <(tail -n +2 ${HIFI_INCORRECT} | cut -f1,5) --divisions <(tail -n +2 ${HIFI_INCORRECT} | cut -f1,4)  --title 'HiFi incorrect read count' --y_label 'Count' --x_label 'Condition' --x_sideways --no_n --categories ${HIFI_SIM_1M_HEADLINE_CATEGORIES}  --colors ${HIFI_SIM_1M_HEADLINE_COLORS} --save ${OUT_DIR}/incorrectness_hifi.pdf
 
@@ -129,11 +131,24 @@ python3 barchart.py <(tail -n +2 ${R10_INCORRECT} | cut -f1,5) --divisions <(tai
 
 ########################################## Clips
 
-HIFI_CLIPS=${ROOT_DIR}/experiments/hifi_real_full_headline/results/clipped_or_unmapped_percent.tsv
-R10_CLIPS=${ROOT_DIR}/experiments/r10y2025_real_full_headline/results/clipped_or_unmapped_percent.tsv
+HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
+R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
+ILLUMINA_REAL=${ROOT_DIR}/experiments/illumina_real_full/results/mapping_stats_real.tsv
+ELEMENT_REAL=${ROOT_DIR}/experiments/element_real_full/results/mapping_stats_real.tsv
 
-HIFI_UNMAPPED=${ROOT_DIR}/experiments/hifi_real_full_headline/results/unmapped_length_percent.tsv
-R10_UNMAPPED=${ROOT_DIR}/experiments/r10y2025_real_full_headline/results/unmapped_length_percent.tsv
+HIFI_UNMAPPED=${OUT_DIR}/hifi_unmapped.tsv 
+R10_UNMAPPED=${OUT_DIR}/r10_unmapped.tsv
+HIFI_CLIPS=${OUT_DIR}/hifi_clips.tsv 
+R10_CLIPS=${OUT_DIR}/r10_clips.tsv
+
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$9/$10}}' > ${HIFI_CLIPS}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$9/$10}}' > ${R10_CLIPS}
+
+
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$8/$10}}' > ${HIFI_UNMAPPED}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$8/$10}}' > ${R10_UNMAPPED}
+cat $HIFI_CLIPS
+cat $HIFI_UNMAPPED
 
 #hifi softclips low
 LIMIT=$(python3 get_outlier_limit.py ${HIFI_CLIPS} small)
@@ -146,15 +161,21 @@ python3 barchart.py ${HIFI_CLIPS} --divisions ${HIFI_UNMAPPED} --min ${LIMIT}  -
 #r10 softclips
 python3 barchart.py ${R10_CLIPS} --divisions ${R10_UNMAPPED} --title 'R10 Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_r10_headline_high.pdf
 
+rm $HIFI_UNMAPPED
+rm $R10_UNMAPPED
+rm $HIFI_CLIPS
+rm $R10_CLIPS
 
 ############################################ Runtime
-
-HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
-R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
+#
 HIFI_RUNTIME=${OUT_DIR}/hifi_runtimes.tsv
 R10_RUNTIME=${OUT_DIR}/r10_runtimes.tsv
+ILLUMINA_RUNTIME=${OUT_DIR}/illumina_runtimes.tsv
+ELEMENT_RUNTIME=${OUT_DIR}/element_runtimes.tsv
 grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} > ${HIFI_RUNTIME}
 grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} > ${R10_RUNTIME}
+grep -E $(echo ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} > ${ILLUMINA_RUNTIME}
+grep -E $(echo ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} > ${ELEMENT_RUNTIME}
 
 
 
@@ -177,17 +198,40 @@ python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --div
 LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) small)
 python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${R10_RUNTIME}) --max ${LIMIT}  --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline_fast.pdf
 
+# Illumina runtimes as one plot
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ILLUMINA_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ILLUMINA_RUNTIME}) --title 'Illumina Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ILLUMINA_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_illumina_headline.pdf
+
+# Element runtimes as one plot
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ELEMENT_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ELEMENT_RUNTIME}) --title 'Element Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ELEMENT_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_element_headline.pdf
+
 rm ${HIFI_RUNTIME}
 rm ${R10_RUNTIME}
-###################################### Memory
+rm ${ILLUMINA_RUNTIME}
+rm ${ELEMENT_RUNTIME}
+####################################### Memory
+#
+HIFI_MEMORY=${OUT_DIR}/hifi_memory.tsv
+R10_MEMORY=${OUT_DIR}/r10_memory.tsv
+ILLUMINA_MEMORY=${OUT_DIR}/illumina_memory.tsv
+ELEMENT_MEMORY=${OUT_DIR}/element_memory.tsv
 
-HIFI_MEMORY=${ROOT_DIR}/experiments/hifi_real_full_headline/results/memory_from_benchmark.tsv
-R10_MEMORY=${ROOT_DIR}/experiments/r10y2025_real_full_headline/results/memory_from_benchmark.tsv
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${HIFI_MEMORY}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${R10_MEMORY}
+grep -E $(echo ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ILLUMINA_MEMORY}
+grep -E $(echo ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ELEMENT_MEMORY}
 
 python3 barchart.py ${HIFI_MEMORY} --title 'HiFi Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_hifi.pdf
 
 python3 barchart.py ${R10_MEMORY} --title 'R10 Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_r10.pdf
 
+python3 barchart.py ${ILLUMINA_MEMORY} --title 'Illumina Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ILLUMINA_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_illumina.pdf
+
+python3 barchart.py ${ELEMENT_MEMORY} --title 'Element Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ELEMENT_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_element.pdf
+
+rm $HIFI_MEMORY
+rm $R10_MEMORY
+rm $ILLUMINA_MEMORY
+rm $ELEMENT_MEMORY
 
 ####################################### SV Calling
 

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -80,8 +80,8 @@ HIFI_SIM_1M_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${PBMM_COLOR} $
 R10_SIM_1M_HEADLINE_CATEGORIES="${MINIMAP_R10} ${WINNOWMAP} ${GIRAFFE_PRIMARY_R10} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_MINIGRAPH} ${GRAPHALIGNER_DEFAULT} ${GIRAFFE_R10} ${GIRAFFE_SAMPLED_R10}"
 R10_SIM_1M_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${MINIGRAPH_MINIGRAPH_COLOR} ${GRAPHALIGNER_MINIGRAPH_COLOR} ${GRAPHALIGNER_DEFAULT_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
-SR_SIM_1M_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR} ${GIRAFFE_PRIMARY_SR}"
-SR_SIM_1M_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR} ${GIRAFFE_PRIMARY_COLOR}"
+SR_SIM_1M_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_PRIMARY_SR} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR}"
+SR_SIM_1M_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
 # graphaligner-default on the M/C graph and graphaligner-default on minigraph timed out after 7 days
 HIFI_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_HIFI} ${WINNOWMAP} ${PBMM} ${GIRAFFE_PRIMARY_HIFI} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_FAST} ${GIRAFFE_HIFI} ${GIRAFFE_SAMPLED_HIFI}"
@@ -91,8 +91,8 @@ HIFI_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${PBMM_COLOR
 R10_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_R10} ${WINNOWMAP} ${GIRAFFE_PRIMARY_R10} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_MINIGRAPH} ${GRAPHALIGNER_FAST} ${GIRAFFE_R10} ${GIRAFFE_SAMPLED_R10}"
 R10_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${MINIGRAPH_MINIGRAPH_COLOR} ${GRAPHALIGNER_MINIGRAPH_COLOR} ${GRAPHALIGNER_FAST_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
-SR_REAL_FULL_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR} ${GIRAFFE_PRIMARY_SR}"
-SR_REAL_FULL_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR} ${GIRAFFE_PRIMARY_COLOR}"
+SR_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_PRIMARY_SR} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR}"
+SR_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
 ########################################### ROCs and QQs
 
@@ -141,12 +141,12 @@ R10_UNMAPPED=${OUT_DIR}/r10_unmapped.tsv
 HIFI_CLIPS=${OUT_DIR}/hifi_clips.tsv 
 R10_CLIPS=${OUT_DIR}/r10_clips.tsv
 
-grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$9/$10}}' > ${HIFI_CLIPS}
-grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$9/$10}}' > ${R10_CLIPS}
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,100*$9/$10}}' > ${HIFI_CLIPS}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,100*$9/$10}}' > ${R10_CLIPS}
 
 
-grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$8/$10}}' > ${HIFI_UNMAPPED}
-grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$8/$10}}' > ${R10_UNMAPPED}
+grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${HIFI_UNMAPPED}
+grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${R10_UNMAPPED}
 cat $HIFI_CLIPS
 cat $HIFI_UNMAPPED
 
@@ -166,16 +166,16 @@ rm $R10_UNMAPPED
 rm $HIFI_CLIPS
 rm $R10_CLIPS
 
-############################################ Runtime
-#
+########################################### Runtime
+
 HIFI_RUNTIME=${OUT_DIR}/hifi_runtimes.tsv
 R10_RUNTIME=${OUT_DIR}/r10_runtimes.tsv
 ILLUMINA_RUNTIME=${OUT_DIR}/illumina_runtimes.tsv
 ELEMENT_RUNTIME=${OUT_DIR}/element_runtimes.tsv
 grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} > ${HIFI_RUNTIME}
 grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} > ${R10_RUNTIME}
-grep -E $(echo ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} > ${ILLUMINA_RUNTIME}
-grep -E $(echo ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} > ${ELEMENT_RUNTIME}
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} > ${ILLUMINA_RUNTIME}
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} > ${ELEMENT_RUNTIME}
 
 
 
@@ -199,34 +199,32 @@ LIMIT=$(python3 get_outlier_limit.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R1
 python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${R10_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${R10_RUNTIME}) --max ${LIMIT}  --title 'R10 Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_r10_headline_fast.pdf
 
 # Illumina runtimes as one plot
-python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ILLUMINA_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ILLUMINA_RUNTIME}) --title 'Illumina Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ILLUMINA_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_illumina_headline.pdf
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ILLUMINA_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ILLUMINA_RUNTIME}) --title 'Illumina Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_illumina_headline.pdf
 
 # Element runtimes as one plot
-python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ELEMENT_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ELEMENT_RUNTIME}) --title 'Element Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ELEMENT_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_element_headline.pdf
+python3 barchart.py <(awk -v OFS='\t' '{{print $1,$2/60}}' ${ELEMENT_RUNTIME}) --divisions <(awk -v OFS='\t' '{{print $1,($3+$4)/60}}' ${ELEMENT_RUNTIME}) --title 'Element Runtime' --y_label 'Time (hours)' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/runtime_element_headline.pdf
 
 rm ${HIFI_RUNTIME}
 rm ${R10_RUNTIME}
 rm ${ILLUMINA_RUNTIME}
 rm ${ELEMENT_RUNTIME}
 ####################################### Memory
-#
-HIFI_MEMORY=${OUT_DIR}/hifi_memory.tsv
 R10_MEMORY=${OUT_DIR}/r10_memory.tsv
 ILLUMINA_MEMORY=${OUT_DIR}/illumina_memory.tsv
 ELEMENT_MEMORY=${OUT_DIR}/element_memory.tsv
 
 grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${HIFI_MEMORY}
 grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${R10_MEMORY}
-grep -E $(echo ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ILLUMINA_MEMORY}
-grep -E $(echo ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ELEMENT_MEMORY}
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ILLUMINA_MEMORY}
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} | awk -v OFS='\t' '{{print $1,$5}}' > ${ELEMENT_MEMORY}
 
 python3 barchart.py ${HIFI_MEMORY} --title 'HiFi Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_hifi.pdf
 
 python3 barchart.py ${R10_MEMORY} --title 'R10 Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_r10.pdf
 
-python3 barchart.py ${ILLUMINA_MEMORY} --title 'Illumina Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${ILLUMINA_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ILLUMINA_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_illumina.pdf
+python3 barchart.py ${ILLUMINA_MEMORY} --title 'Illumina Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_illumina.pdf
 
-python3 barchart.py ${ELEMENT_MEMORY} --title 'Element Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${ELEMENT_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${ELEMENT_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_element.pdf
+python3 barchart.py ${ELEMENT_MEMORY} --title 'Element Memory From Benchmark' --y_label 'Memory (GB)' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/memory_element.pdf
 
 rm $HIFI_MEMORY
 rm $R10_MEMORY

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -94,13 +94,28 @@ R10_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRI
 SR_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_PRIMARY_SR} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR}"
 SR_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
 
-########################################### ROCs and QQs
+############################################### All input files
 
-# Zoomed in headline roc plots
 HIFI_ACCURACY=${ROOT_DIR}/experiments/hifi_sim_1m/results/compared.tsv
 R10_ACCURACY=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/compared.tsv
 ILLUMINA_ACCURACY=${ROOT_DIR}/experiments/illumina_sim_1m/results/compared.tsv
 ELEMENT_ACCURACY=${ROOT_DIR}/experiments/element_sim_1m/results/compared.tsv
+
+HIFI_SIM=${ROOT_DIR}/experiments/hifi_sim_1m/results/mapping_stats_sim.tsv
+R10_SIM=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/mapping_stats_sim.tsv
+
+HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
+R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
+ILLUMINA_REAL=${ROOT_DIR}/experiments/illumina_real_full/results/mapping_stats_real.tsv
+ELEMENT_REAL=${ROOT_DIR}/experiments/element_real_full/results/mapping_stats_real.tsv
+
+SV_SUMMARY=${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv
+SNP_SUMMARY=${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv
+INDEL_SUMMARY=${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv
+
+########################################### ROCs and QQs
+
+# Zoomed in headline roc plots
 
 Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.0001,0.03,0.9545,0.995'
 
@@ -122,22 +137,18 @@ Rscript plot-qq.R ${R10_ACCURACY} ${OUT_DIR}/qq_r10_headline.pdf $(echo $R10_SIM
 
 ########################################## Incorrect counts
 
-HIFI_INCORRECT=${ROOT_DIR}/experiments/hifi_sim_1m/results/mapping_stats_sim.tsv
-R10_INCORRECT=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/mapping_stats_sim.tsv
 
-python3 barchart.py <(tail -n +2 ${HIFI_INCORRECT} | cut -f1,5) --divisions <(tail -n +2 ${HIFI_INCORRECT} | cut -f1,4)  --title 'HiFi incorrect read count' --y_label 'Count' --x_label 'Condition' --x_sideways --no_n --categories ${HIFI_SIM_1M_HEADLINE_CATEGORIES}  --colors ${HIFI_SIM_1M_HEADLINE_COLORS} --save ${OUT_DIR}/incorrectness_hifi.pdf
+python3 barchart.py <(tail -n +2 ${HIFI_SIM} | cut -f1,5) --divisions <(tail -n +2 ${HIFI_SIM} | cut -f1,4)  --title 'HiFi incorrect read count' --y_label 'Count' --x_label 'Condition' --x_sideways --no_n --categories ${HIFI_SIM_1M_HEADLINE_CATEGORIES}  --colors ${HIFI_SIM_1M_HEADLINE_COLORS} --save ${OUT_DIR}/incorrectness_hifi.pdf
 
-python3 barchart.py <(tail -n +2 ${R10_INCORRECT} | cut -f1,5) --divisions <(tail -n +2 ${R10_INCORRECT} | cut -f1,4)  --title 'R10 incorrect read count' --y_label 'Count' --x_label 'Condition' --x_sideways --no_n --categories ${R10_SIM_1M_HEADLINE_CATEGORIES}  --colors ${R10_SIM_1M_HEADLINE_COLORS}  --save ${OUT_DIR}/incorrectness_r10.pdf
+python3 barchart.py <(tail -n +2 ${R10_SIM} | cut -f1,5) --divisions <(tail -n +2 ${R10_SIM} | cut -f1,4)  --title 'R10 incorrect read count' --y_label 'Count' --x_label 'Condition' --x_sideways --no_n --categories ${R10_SIM_1M_HEADLINE_CATEGORIES}  --colors ${R10_SIM_1M_HEADLINE_COLORS}  --save ${OUT_DIR}/incorrectness_r10.pdf
 
 ########################################## Clips
 
-HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
-R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
-ILLUMINA_REAL=${ROOT_DIR}/experiments/illumina_real_full/results/mapping_stats_real.tsv
-ELEMENT_REAL=${ROOT_DIR}/experiments/element_real_full/results/mapping_stats_real.tsv
 
 HIFI_UNMAPPED=${OUT_DIR}/hifi_unmapped.tsv 
 R10_UNMAPPED=${OUT_DIR}/r10_unmapped.tsv
+ILLUMINA_UNMAPPED=${OUT_DIR}/illumina_unmapped.tsv 
+ELEMENT_UNMAPPED=${OUT_DIR}/element_unmapped.tsv 
 HIFI_CLIPS=${OUT_DIR}/hifi_clips.tsv 
 R10_CLIPS=${OUT_DIR}/r10_clips.tsv
 
@@ -147,8 +158,8 @@ grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL}
 
 grep -E $(echo ${HIFI_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${HIFI_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${HIFI_UNMAPPED}
 grep -E $(echo ${R10_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${R10_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${R10_UNMAPPED}
-cat $HIFI_CLIPS
-cat $HIFI_UNMAPPED
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ILLUMINA_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${ILLUMINA_UNMAPPED}
+grep -E $(echo ${SR_REAL_FULL_HEADLINE_CATEGORIES} | sed 's/ /|/g') ${ELEMENT_REAL} | awk -v OFS='\t' '{{print $1,100*$8/$10}}' > ${ELEMENT_UNMAPPED}
 
 #hifi softclips low
 LIMIT=$(python3 get_outlier_limit.py ${HIFI_CLIPS} small)
@@ -159,10 +170,18 @@ LIMIT=$(python3 get_outlier_limit.py ${HIFI_CLIPS} big)
 python3 barchart.py ${HIFI_CLIPS} --divisions ${HIFI_UNMAPPED} --min ${LIMIT}  --title 'HiFi Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${HIFI_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${HIFI_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_hifi_headline_high.pdf
 
 #r10 softclips
-python3 barchart.py ${R10_CLIPS} --divisions ${R10_UNMAPPED} --title 'R10 Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_r10_headline_high.pdf
+python3 barchart.py ${R10_CLIPS} --divisions ${R10_UNMAPPED} --title 'R10 Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${R10_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${R10_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_r10_headline.pdf
+
+#illumina softclips
+python3 barchart.py ${ILLUMINA_UNMAPPED} --title 'ILLUMINA Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_illumina_headline.pdf
+
+#element softclips
+python3 barchart.py ${ELEMENT_UNMAPPED} --title 'ELEMENT Clipped or Unmapped Bases' --y_label 'Percent of bases' --x_label 'Mapper' --x_sideways --no_n --categories ${SR_REAL_FULL_HEADLINE_CATEGORIES}  --colors ${SR_REAL_FULL_HEADLINE_COLORS} --save ${OUT_DIR}/softclips_element_headline.pdf
 
 rm $HIFI_UNMAPPED
 rm $R10_UNMAPPED
+rm $ILLUMINA_UNMAPPED
+rm $ELEMENT_UNMAPPED
 rm $HIFI_CLIPS
 rm $R10_CLIPS
 
@@ -244,8 +263,8 @@ MINIMAP_SNIFFLES_R10=chm13,chm13,sniffles,r10y2025,minimap2-lr:hqae,eval-d46
 SV_CALLING_CONDITIONS_HIFI="${GIRAFFE_VGCALL_HIFI};${GIRAFFE_SAMPLED_VGCALL_HIFI};${MINIMAP_SNIFFLES_HIFI}"
 SV_CALLING_CONDITIONS_R10="${GIRAFFE_VGCALL_R10};${GIRAFFE_SAMPLED_VGCALL_R10};${MINIMAP_SNIFFLES_R10}"
 
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv ${OUT_DIR}/sv_summary_hifi.pdf ${SV_CALLING_CONDITIONS_HIFI}
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv ${OUT_DIR}/sv_summary_r10.pdf ${SV_CALLING_CONDITIONS_R10}
+Rscript plot-calling-results.R ${SV_SUMMARY} ${OUT_DIR}/sv_summary_hifi.pdf ${SV_CALLING_CONDITIONS_HIFI}
+Rscript plot-calling-results.R ${SV_SUMMARY} ${OUT_DIR}/sv_summary_r10.pdf ${SV_CALLING_CONDITIONS_R10}
 
 ############################################# DV Calling
 
@@ -262,8 +281,8 @@ MINIMAP_DV_R10=r10y2025,minimap2-lr:hqae,eval-d46,.nomodel
 DV_CALLING_CONDITIONS_R10="${GIRAFFE_DV_R10};${GIRAFFE_SAMPLED_DV_R10};${MINIMAP_DV_R10}"
 
 
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv ${OUT_DIR}/dv_snp_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
+Rscript plot-calling-results.R ${SNP_SUMMARY} ${OUT_DIR}/dv_snp_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
+Rscript plot-calling-results.R ${INDEL_SUMMARY} ${OUT_DIR}/dv_indel_summary_hifi.pdf ${DV_CALLING_CONDITIONS_HIFI}
 
-Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv ${OUT_DIR}/dv_snp_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
-#Rscript plot-calling-results.R ${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv ${OUT_DIR}/dv_indel_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
+Rscript plot-calling-results.R ${SNP_SUMMARY} ${OUT_DIR}/dv_snp_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}
+Rscript plot-calling-results.R ${INDEL_SUMMARY} ${OUT_DIR}/dv_indel_summary_r10.pdf ${DV_CALLING_CONDITIONS_R10}

--- a/make_paper_figures.sh
+++ b/make_paper_figures.sh
@@ -34,8 +34,10 @@ YELLOW=#F2C300
 DARK_ORANGE=#C44601
 ORANGE=#F57600
 PINK=#D066A3
+LIGHT_GREEN=#9CDA4D
 
 
+BWA_COLOR=${LIGHT_GREEN}
 MINIMAP_COLOR=${PURPLE}
 WINNOWMAP_COLOR=${LIGHT_PURPLE}
 GIRAFFE_PRIMARY_COLOR=${BLUE}
@@ -50,10 +52,13 @@ GIRAFFE_SAMPLED_COLOR=${ORANGE}
 ######################################### Define conditions
 MINIMAP_HIFI=minimap2-map-hifi,hprc-v2.0-mc-eval-d46
 MINIMAP_R10=minimap2-lr:hqae,hprc-v2.0-mc-eval-d46
+MINIMAP_SR=minimap2-sr,hprc-v2.0-mc-eval-d46
 WINNOWMAP=winnowmap,hprc-v2.0-mc-eval-d46
 GIRAFFE_PRIMARY_HIFI=giraffe,primary
 GIRAFFE_PRIMARY_R10=giraffe,primary
+GIRAFFE_PRIMARY_SR=giraffe,primary
 PBMM=pbmm2,hprc-v2.0-mc-eval-d46
+BWA=bwa,hprc-v2.0-mc-eval-d46
 
 MINIGRAPH_MINIGRAPH=minigraph,hprc-v2.0-minigraph-eval
 GRAPHALIGNER_MINIGRAPH=graphaligner-default,hprc-v2.0-minigraph-eval
@@ -62,9 +67,11 @@ GRAPHALIGNER_DEFAULT=graphaligner-default,hprc-v2.0-mc-eval-d46
 GRAPHALIGNER_FAST=graphaligner-fast,hprc-v2.0-mc-eval-d46
 GIRAFFE_HIFI=giraffe,hprc-v2.0-mc-eval-d46
 GIRAFFE_R10=giraffe,hprc-v2.0-mc-eval-d46
+GIRAFFE_SR=giraffe,hprc-v2.0-mc-eval-d46
 
 GIRAFFE_SAMPLED_HIFI=giraffe,hprc-v2.0-mc-eval.ec1M-sampled16o
 GIRAFFE_SAMPLED_R10=giraffe,hprc-v2.0-mc-eval.ec1M-sampled16o
+GIRAFFE_SAMPLED_SR=giraffe,hprc-v2.0-mc-eval.ec1M-sampled16o
 
 ###################################### Define conditions and colors for each experiment
 
@@ -73,6 +80,9 @@ HIFI_SIM_1M_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${PBMM_COLOR} $
 
 R10_SIM_1M_HEADLINE_CATEGORIES="${MINIMAP_R10} ${WINNOWMAP} ${GIRAFFE_PRIMARY_R10} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_MINIGRAPH} ${GRAPHALIGNER_DEFAULT} ${GIRAFFE_R10} ${GIRAFFE_SAMPLED_R10}"
 R10_SIM_1M_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRIMARY_COLOR} ${MINIGRAPH_MINIGRAPH_COLOR} ${GRAPHALIGNER_MINIGRAPH_COLOR} ${GRAPHALIGNER_DEFAULT_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR}"
+
+SR_SIM_1M_CATEGORIES="${MINIMAP_SR} ${BWA} ${GIRAFFE_SR} ${GIRAFFE_SAMPLED_SR} ${GIRAFFE_PRIMARY_SR}"
+SR_SIM_1M_COLORS="${MINIMAP_COLOR} ${BWA_COLOR} ${GIRAFFE_COLOR} ${GIRAFFE_SAMPLED_COLOR} ${GIRAFFE_PRIMARY_COLOR}"
 
 # graphaligner-default on the M/C graph and graphaligner-default on minigraph timed out after 7 days
 HIFI_REAL_FULL_HEADLINE_CATEGORIES="${MINIMAP_HIFI} ${WINNOWMAP} ${PBMM} ${GIRAFFE_PRIMARY_HIFI} ${MINIGRAPH_MINIGRAPH} ${GRAPHALIGNER_FAST} ${GIRAFFE_HIFI} ${GIRAFFE_SAMPLED_HIFI}"
@@ -88,15 +98,21 @@ R10_REAL_FULL_HEADLINE_COLORS="${MINIMAP_COLOR} ${WINNOWMAP_COLOR} ${GIRAFFE_PRI
 # Zoomed in headline roc plots
 HIFI_ACCURACY=${ROOT_DIR}/experiments/hifi_sim_1m_headline/results/compared.tsv
 R10_ACCURACY=${ROOT_DIR}/experiments/r10y2025_sim_1m_headline/results/compared.tsv
+ILLUMINA_ACCURACY=${ROOT_DIR}/experiments/illumina_sim_1m/results/compared.tsv
+ELEMENT_ACCURACY=${ROOT_DIR}/experiments/element_sim_1m/results/compared.tsv
 
-Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.005,0.0085,0.9905,0.9945'
+Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline_zoomed.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.03,0.9775,0.995'
 
-Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline_zoomed.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.004,0.010,0.990,0.994'
+Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline_zoomed.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' ) '0.001,0.030,0.965,0.994'
 
 # Zoomed out headline roc plots
 Rscript plot-roc.R ${HIFI_ACCURACY} ${OUT_DIR}/roc_hifi_headline.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI ROC" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
 
 Rscript plot-roc.R ${R10_ACCURACY} ${OUT_DIR}/roc_r10_headline.pdf $(echo $R10_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "R10 ROC" $(echo $R10_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )
+
+Rscript plot-roc.R ${ILLUMINA_ACCURACY} ${OUT_DIR}/roc_illumina_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Illumina ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
+
+Rscript plot-roc.R ${ELEMENT_ACCURACY} ${OUT_DIR}/roc_element_headline.pdf $(echo $SR_SIM_1M_CATEGORIES | sed 's/ /;/g' ) "Element ROC" $(echo $SR_SIM_1M_COLORS | sed 's/ /,/g' )
 
 # headline qq plots
 Rscript plot-qq.R ${HIFI_ACCURACY} ${OUT_DIR}/qq_hifi_headline.pdf $(echo $HIFI_SIM_1M_HEADLINE_CATEGORIES | sed 's/ /;/g' ) "HIFI QQ" $(echo $HIFI_SIM_1M_HEADLINE_COLORS | sed 's/ /,/g' )

--- a/make_paper_tables.sh
+++ b/make_paper_tables.sh
@@ -1,0 +1,93 @@
+set -ex
+
+ROOT_DIR=/private/groups/patenlab/project-lrg
+OUT_DIR=./tables
+mkdir -p "${OUT_DIR}"
+
+############################################### All input files
+
+
+HIFI_SIM=${ROOT_DIR}/experiments/hifi_sim_1m/results/mapping_stats_sim.tsv
+R10_SIM=${ROOT_DIR}/experiments/r10y2025_sim_1m/results/mapping_stats_sim.tsv
+ILLUMINA_SIM=${ROOT_DIR}/experiments/illumina_sim_1m/results/mapping_stats_sim.tsv
+ELEMENT_SIM=${ROOT_DIR}/experiments/element_sim_1m/results/mapping_stats_sim.tsv
+
+HIFI_REAL=${ROOT_DIR}/experiments/hifi_real_full/results/mapping_stats_real.tsv
+R10_REAL=${ROOT_DIR}/experiments/r10y2025_real_full/results/mapping_stats_real.tsv
+ILLUMINA_REAL=${ROOT_DIR}/experiments/illumina_real_full/results/mapping_stats_real.tsv
+ELEMENT_REAL=${ROOT_DIR}/experiments/element_real_full/results/mapping_stats_real.tsv
+
+SV_SUMMARY=${ROOT_DIR}/experiments/sv_calling/results/sv_summary.tsv
+SNP_SUMMARY=${ROOT_DIR}/experiments/dv_calling/results/dv_snp_summary.tsv
+INDEL_SUMMARY=${ROOT_DIR}/experiments/dv_calling/results/dv_indel_summary.tsv
+
+################################### Simulated read tables
+
+# Assumes 1 mil reads
+for SIM_FILE in $HIFI_SIM $R10_SIM $ILLUMINA_SIM $ELEMENT_SIM ;
+do
+
+    CURRENT_OUTFILE=${OUT_DIR}/trash.txt
+    if [ $SIM_FILE == $HIFI_SIM ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/simulated_hifi.tsv
+    elif [ $SIM_FILE == $R10_SIM ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/simulated_r10.tsv
+    elif [ $SIM_FILE == $ILLUMINA_SIM ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/simulated_illumina.tsv
+    elif [ $SIM_FILE == $ELEMENT_SIM ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/simulated_element.tsv
+    fi    
+    printf "Reference\t& Mapper\t& Correct\t& Mapq60\t& Wrong \\\\\\ \n" >$CURRENT_OUTFILE
+    printf "\t& \t& (\\%%) \t& (\\%%) \t& Mapq60 (\\%%) \\\\\\ \n" >>$CURRENT_OUTFILE
+    printf "\\hline\n" >> $CURRENT_OUTFILE
+    tail -n +2 ${SIM_FILE} | awk -v OFS='\t' '{print $1,$2/10000,$3/10000,$4/10000}' | ./format_tsv.sh >> $CURRENT_OUTFILE 
+done
+
+################################### Real read tables
+
+
+for REAL_FILE in $HIFI_REAL $R10_REAL ;
+do
+
+    CURRENT_OUTFILE=${OUT_DIR}/trash.txt
+    if [ $REAL_FILE == $HIFI_REAL ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/real_hifi.tsv
+    elif [ $REAL_FILE == $R10_REAL ]; then
+        CURRENT_OUTFILE=${OUT_DIR}/real_r10.tsv
+    fi    
+    printf "Reference\t& Mapper\t& Runtime (min)\t& Index time (min)\t& Memory (GB)\t& Soft- or Hard-&\t Unmapped \\\\\\ \n" >$CURRENT_OUTFILE
+    printf "\t& \t& \t& (+ Sampling (min)) \t& \t& clipped Bases (\\%%)\t& Bases (\\%%) \\\\\\ \n" >>$CURRENT_OUTFILE
+    printf "\\hline\n" >> $CURRENT_OUTFILE
+    tail -n +2 ${REAL_FILE} | awk -v OFS='\t' '{printf "%0s\t%.4f\t%.4f\t%.4f\t%.4f\t%.4f\n",$1,$2,$3,$5,(100*($6+$7))/$10,(100*$8)/$10}' | ./format_tsv.sh >> $CURRENT_OUTFILE 
+    printf "SAMPLING TIMES\n" >>$CURRENT_OUTFILE
+    tail -n +2 ${REAL_FILE} | awk -v OFS='\t' '$4 != 0 {print $1,$4}'  >> $CURRENT_OUTFILE 
+done
+
+################################# DV Table
+
+for TECH in HIFI R10 ;
+do
+    for VAR in SNP INDEL ;
+        do
+        VAR_FILE=${SNP_SUMMARY}
+        if [ $VAR == SNP ]; then
+            VAR_FILE=${SNP_SUMMARY}
+        elif [ $VAR == INDEL ]; then
+            VAR_FILE=${INDEL_SUMMARY} 
+        elif [ $VAR == SV ]; then
+            VAR_FILE=${SV_SUMMARY} 
+        fi 
+        CURRENT_OUTFILE=${OUT_DIR}/${VAR}_${TECH}.tsv
+        printf "Reference\t& Mapper\t& True\t& False\t& False\t& Recall\t& Precision\t& F1 \\\\\\ \n" >$CURRENT_OUTFILE
+        printf "\t& \t& Positive\t& Negative\t& Positive\t& \t& \t&  \\\\\\ \n" >>$CURRENT_OUTFILE
+        printf "\\hline\n" >> $CURRENT_OUTFILE
+        TEMP_FILE=${OUT_DIR}/tmp.txt
+        if [ $TECH == HIFI ]; then
+            tail -n +2 ${VAR_FILE} | grep hifi | sed 's/^hifi,//g' >$TEMP_FILE 
+        elif [ $TECH == R10 ]; then
+            tail -n +2 ${VAR_FILE} | grep r10 | sed 's/^r10y2025,//g' >$TEMP_FILE 
+        fi
+        cat ${TEMP_FILE} | sed -r 's/,.(model2025-03-26noinfo|nomodel)//' | sed 's/eval/HPRC/g' | sed -r 's/giraffe-(r10|hifi)-(noflags|mmcs100)/Giraffe/g' | awk -v OFS='\t' '{printf "%0s\t%0i\t%0i\t%0i\t%.4f\t%.4f\t%.4f\n",$1,$2,$3,$4,$5,$6,$7}' | ./format_tsv.sh >> $CURRENT_OUTFILE
+        rm $TEMP_FILE
+    done
+done

--- a/plot-calling-results.R
+++ b/plot-calling-results.R
@@ -2,16 +2,38 @@ library(dplyr)
 library(ggplot2)
 library(tidyr)
 
-# plot-calling-results.R <stats TSV> <destination image file> [<comma-separated "aligner" names to include> [title]]
+# plot-calling-results.R <stats TSV> <destination image file> [<semicolon-separated "condition" names to include> [title]]
 
 #Input is a tsv of condition name, followed by tp, fn, fp, recall, precision, f1
 dat <- read.table(commandArgs(TRUE)[1], header=T)
 
+if (length(commandArgs(TRUE)) > 2) {
+    # A set of aligners to plot is specified. Parse it.
+    condition.set <- unlist(strsplit(commandArgs(TRUE)[3], ";"))
+    # Subset the data to those aligners
+    dat <- dat[dat$condition %in% condition.set,]
+    # And restrict the condition factor levels to just the ones in the set
+    dat$condition <- factor(dat$condition, levels=condition.set)
+}
 
 ## save a PDF
-pdf(commandArgs(TRUE)[2], 9, 3)
+pdf(commandArgs(TRUE)[2], 7, 3)
 
 ## comparing F1
+## Without name
+dat %>% 
+  select(condition, F1, recall, precision) %>% 
+  pivot_longer(cols=c(F1, recall, precision), names_to='metric', values_to='value') %>%
+  ggplot(aes(x=condition, color=metric, y=value)) +
+  geom_hline(yintercept=1, linetype=2) + 
+  geom_line(aes(group=condition), linewidth=0.75, color='black', alpha=.8) +
+  geom_point( alpha=.8, size=3) +
+  theme_bw() +
+  scale_color_brewer(palette="Set2") +
+  coord_flip() + 
+  theme(legend.position='bottom', axis.text.y=element_blank())
+
+## With name
 dat %>% 
   select(condition, F1, recall, precision) %>% 
   pivot_longer(cols=c(F1, recall, precision), names_to='metric', values_to='value') %>%
@@ -24,7 +46,22 @@ dat %>%
   coord_flip() + 
   theme(legend.position='bottom')
 
+
+
 ## comparing errors (FP and FN)
+## Without name
+dat %>% 
+  select(condition, FP, FN) %>% 
+  pivot_longer(cols=c(FP, FN), names_to='error', values_to='count') %>%
+  ggplot(aes(x=condition, fill=error, y=count)) +
+  geom_col() +
+  scale_fill_brewer(palette="Set2") +
+  ylab('variant call') + 
+  theme_bw() +
+  coord_flip() + 
+  theme(legend.position='bottom', axis.text.y=element_blank())
+
+## With name
 dat %>% 
   select(condition, FP, FN) %>% 
   pivot_longer(cols=c(FP, FN), names_to='error', values_to='count') %>%

--- a/plot-qq.R
+++ b/plot-qq.R
@@ -88,4 +88,7 @@ if (title != '') {
 }
 
 filename <- commandArgs(TRUE)[2]
-ggsave(filename, height=4, width=7)
+pdf(filename, 4.5, 4)
+dat.plot + guides(color="none", size="none")
+dat.plot
+dev.off()


### PR DESCRIPTION
Streamline making figures and tables. This removes some rules that I think were redundant. Everything for the paper should be found in `mapping_stats_real/sim` or `compared.tsv` for roc/qq plots